### PR TITLE
use future cog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           python-version: '3.8.12'
         run:
-          pip install pytest
+      
+      - name: Install pytest
+      - run: python my_script.py
 
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.8.12'
-        run:
       
       - name: Install pytest
         run: python my_script.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,5 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      # - name: Checkout Cog repo
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: replicate/cog
-      #     # ref: 'future'
-      #     path: cog
-
       - name: Run tests
         run: script/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
 
 jobs:
   test:
+    name: Python tests
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+steps:
+  - name: Set up Python
+    uses: actions/setup-python@v2
+    with:
+      python-version: '3.8.12'
+
+  - name: Checkout repo
+    uses: actions/checkout@v2
+
+  - name: Checkout Cog repo
+    uses: actions/checkout@v2
+    with:
+      repository: replicate/cog
+      # ref: 'future'
+      path: cog
+
+  - name: Run tests
+    run: script/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,21 +4,23 @@ on:
   push:
   pull_request:
 
-steps:
-  - name: Set up Python
-    uses: actions/setup-python@v2
-    with:
-      python-version: '3.8.12'
+jobs:
+  test:
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.12'
 
-  - name: Checkout repo
-    uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
-  - name: Checkout Cog repo
-    uses: actions/checkout@v2
-    with:
-      repository: replicate/cog
-      # ref: 'future'
-      path: cog
+      - name: Checkout Cog repo
+        uses: actions/checkout@v2
+        with:
+          repository: replicate/cog
+          # ref: 'future'
+          path: cog
 
-  - name: Run tests
-    run: script/test
+      - name: Run tests
+        run: script/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         run:
       
       - name: Install pytest
-      - run: python my_script.py
+        run: python my_script.py
 
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.8.12'
       
       - name: Install pytest
-        run: python my_script.py
+        run: pip install pytest
 
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Python tests
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.12'
+      
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: script/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.8.12'
+        run:
+          pip install pytest
 
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Checkout Cog repo
-        uses: actions/checkout@v2
-        with:
-          repository: replicate/cog
-          # ref: 'future'
-          path: cog
+      # - name: Checkout Cog repo
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: replicate/cog
+      #     # ref: 'future'
+      #     path: cog
 
       - name: Run tests
         run: script/test

--- a/predict.py
+++ b/predict.py
@@ -1,14 +1,14 @@
-import cog
+from cog import BasePredictor, Input
 import haiku
 import random
 
-class Predictor(cog.Predictor):
+class Predictor(BasePredictor):
     def setup(self):
       self.haikus = haiku.load_all()
 
-    @cog.input("seed", type=int, help="An optional random seed", min=0, max=1000, default=None)
-    def predict(self, seed):
+    def predict(self, 
+      seed: int = Input(description="An optional random seed", ge=0, default=None)) -> str:
       if seed:
-        return self.haikus[seed]
+        return self.haikus[seed % len(self.haikus)]
       else:
         return random.choice(self.haikus)

--- a/script/test
+++ b/script/test
@@ -9,6 +9,8 @@ if [ ! -d "cog" ]
 then
 git clone https://github.com/replicate/cog
 cd cog
+# use the new unreleased version of cog
+git switch future
 pip install -r requirements-dev.txt
 cd python
 python setup.py develop


### PR DESCRIPTION
This PR updates the model to use to the new (as yet unreleased) ["future" version of Cog](https://github.com/replicate/cog/pull/407) with a new Python API.

It also introduces a new GitHub Actions workflow that packages future cog  so it can be imported into the python tests.

cc @andreasjansson @bfirsh @evilstreak

