### PR TITLE
support progressive output

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,4 +1,4 @@
 build:
   gpu: false
   python_version: "3.8"
-predict: "predict.py:Predictor"
+predict: "predict.py:StandardPredictor"

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,4 +1,11 @@
 build:
   gpu: false
   python_version: "3.8"
+
+# Comment out one or the other when doing cog push:
+
+# cog push r8.im/zeke/haiku-standard
 predict: "predict.py:StandardPredictor"
+
+# cog push r8.im/zeke/haiku-progressive
+# predict: "predict.py:ProgressivePredictor"

--- a/predict.py
+++ b/predict.py
@@ -1,4 +1,6 @@
 from cog import BasePredictor, Input
+from typing import Any
+import time
 import haiku
 import random
 
@@ -7,8 +9,22 @@ class Predictor(BasePredictor):
       self.haikus = haiku.load_all()
 
     def predict(self, 
-      seed: int = Input(description="An optional random seed", ge=0, default=None)) -> str:
-      if seed:
-        return self.haikus[seed % len(self.haikus)]
-      else:
-        return random.choice(self.haikus)
+      seed: int = Input(description="A seed to always return the same result (optional, defaults to a random integer)", ge=0, default=None),
+      progressive: bool = Input(description="Yield haiku words one at a time, sleepin between each word", default=False),
+      sleep: float = Input(description="Time to sleep between each word (when using progressive output)", default=0.5),
+      ) -> Any:
+        if seed:
+          haiku = self.haikus[seed % len(self.haikus)]
+        else:
+          haiku = random.choice(self.haikus)
+
+        print("seed: ", seed)
+        print("progressive: ", progressive)
+        print("sleep: ", sleep)
+
+        if progressive:
+          for word in haiku.split():
+            yield word
+            time.sleep(sleep)
+        else:
+          return haiku

--- a/predict.py
+++ b/predict.py
@@ -1,30 +1,43 @@
 from cog import BasePredictor, Input
-from typing import Any
+from typing import Generator
 import time
 import haiku
 import random
 
-class Predictor(BasePredictor):
+class HaikuBasePredictor(BasePredictor):
+    """
+    Base predictor from which Standard and Progressive predictors inherit
+    """
     def setup(self):
       self.haikus = haiku.load_all()
 
+    def get_haiku(self, seed: int = None) -> str:
+      if seed and type(seed) == int:
+        return self.haikus[seed % len(self.haikus)]
+      
+      return random.choice(self.haikus)
+
+class StandardPredictor(HaikuBasePredictor):
+    """
+    Return haiku as a single string.
+    """
     def predict(self, 
-      seed: int = Input(description="A seed to always return the same result (optional, defaults to a random integer)", ge=0, default=None),
-      progressive: bool = Input(description="Yield haiku words one at a time, sleepin between each word", default=False),
-      sleep: float = Input(description="Time to sleep between each word (when using progressive output)", default=0.5),
-      ) -> Any:
-        if seed:
-          haiku = self.haikus[seed % len(self.haikus)]
-        else:
-          haiku = random.choice(self.haikus)
+      seed: int = Input(description="A seed to always return the same result (optional)", ge=0, default=None)
+      ) -> str:
+        haiku = self.get_haiku(seed)
+        return haiku
 
-        print("seed: ", seed)
-        print("progressive: ", progressive)
-        print("sleep: ", sleep)
+class ProgressivePredictor(HaikuBasePredictor):
+    """
+    Yield haiku as progressive output, one word at a time.
+    """
+    def predict(self, 
+      seed: int = Input(description="A seed to always return the same result (optional)", ge=0, default=None),
+      sleep: float = Input(description="Time to sleep between each word (when using progressive output)", default=0.1),
+      ) -> Generator[str, None, None]:
 
-        if progressive:
-          for word in haiku.split():
-            yield word
-            time.sleep(sleep)
-        else:
-          return haiku
+        haiku = self.get_haiku(seed)
+
+        for word in haiku.split():
+          yield word
+          time.sleep(sleep)

--- a/test_predict.py
+++ b/test_predict.py
@@ -1,21 +1,42 @@
-from predict import Predictor
+from predict import StandardPredictor, ProgressivePredictor
 
-def test_seed_always_returns_same_haiku():
-  p = Predictor()
-  p.setup()
-  output = p.predict(seed=123)
-  assert "pear blossoms" in output
 
-  output = p.predict(seed=123)
-  assert "pear blossoms" in output
+class TestStandardPredictor:
+  def test_seed_always_returns_same_haiku(self):
+    p = StandardPredictor()
+    p.setup()
+    output = p.predict(seed=123)
+    assert "pear blossoms" in output
 
-def test_without_seed_returns_random_haiku():
-  p = Predictor()
-  p.setup()
-  output1 = p.predict(seed=None)
-  assert isinstance(output1, str)
+    output = p.predict(seed=123)
+    assert "pear blossoms" in output
 
-  output2 = p.predict(seed=None)
-  assert isinstance(output2, str)
+  def test_without_seed_returns_random_haiku(self):
+    p = StandardPredictor()
+    p.setup()
+    output1 = p.predict(seed=None)
+    assert isinstance(output1, str)
 
-  assert output1 != output2
+    output2 = p.predict(seed=None)
+    assert isinstance(output2, str)
+
+    assert output1 != output2
+
+class TestProgressivePredictor:
+  def test_seed_always_returns_same_haiku(self):
+    p = ProgressivePredictor()
+    p.setup()
+    output = [result for result in p.predict(seed=123, sleep=0.1)]
+    assert(len(output) == 9)
+    assert(" ".join(output) == "from somewhere pear blossoms a curve in the road")
+
+  def test_without_seed_returns_random_haiku(self):
+    p = ProgressivePredictor()
+    p.setup()
+    output1 = [result for result in p.predict(sleep=0.01)]
+    assert(len(output1) > 5)
+
+    output2 = [result for result in p.predict(sleep=0.01)]
+    assert(len(output2) > 5)
+    
+    assert output1 != output2


### PR DESCRIPTION
This  adds two new arguments to the Predictor: `progressive` and `sleep`. If `progressive` is enabled, the resulting haiku is yielded one word at a time, sleeping between each word. We can use this to help test progressive output in [future cog](https://github.com/replicate/cog/pull/407).