### PR TITLE
test Cog model responses over FastAPI HTTP server

### DIFF
--- a/script/test
+++ b/script/test
@@ -9,7 +9,6 @@ if [ ! -d "cog" ]
 then
 git clone https://github.com/replicate/cog
 cd cog
-# use the new unreleased version of cog
 git switch future
 pip install -r requirements-dev.txt
 cd python

--- a/script/test
+++ b/script/test
@@ -17,6 +17,6 @@ cd ../..
 fi
 
 # manually install python packages
-pip install pillow colorthief numpy
+pip install pillow colorthief numpy fastapi
 
-pytest -s test_predict.py
+pytest -s test_*.py

--- a/test_http.py
+++ b/test_http.py
@@ -1,0 +1,60 @@
+from cog.server.http import create_app
+from fastapi.testclient import TestClient
+
+from cog import BasePredictor
+from predict import ImagePredictor, ProgressivePredictor, StandardPredictor
+
+
+def make_client(predictor: BasePredictor, **kwargs) -> TestClient:
+    app = create_app(predictor)
+    with TestClient(app, **kwargs) as client:
+        return client
+
+def test_setup_is_called():
+    class Predictor(BasePredictor):
+        def setup(self):
+            self.foo = "bar"
+
+        def predict(self) -> str:
+            return self.foo
+
+    client = make_client(Predictor())
+    resp = client.post("/predictions")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "success", "output": "bar"}
+
+class TestStandardPredictor:
+  def test_with_seed(self):
+      client = make_client(StandardPredictor())
+      resp = client.post("/predictions", json={"input": {"seed": 123}})
+      assert resp.status_code == 200
+      assert resp.json() == {"status": "success", "output": "from somewhere\npear blossoms\n\na curve in the road"}
+
+  def test_without_seed(self):
+      client = make_client(StandardPredictor())
+      resp = client.post("/predictions")
+      assert resp.status_code == 200
+      output1 = resp.json()["output"]
+      assert(len(output1) > 10)
+
+      resp = client.post("/predictions")
+      assert resp.status_code == 200
+      output2 = resp.json()["output"]
+      assert(len(output2) > 10)
+
+      assert(output1 != output2)
+
+class TestProgressivePredictor:
+  def test_returns_last_yielded_output(self):
+      client = make_client(ProgressivePredictor())
+      resp = client.post("/predictions", json={"input": {"seed": 123}})
+      assert resp.status_code == 200
+      assert resp.json() == {"status": "success", "output": "road"} # last word
+
+class TestImagePredictor:
+  def test_returns_an_image(self):
+      client = make_client(ImagePredictor())
+      resp = client.post("/predictions", json={"input": {"seed": 123}})
+      assert resp.status_code == 200
+      header, b64data = resp.json()["output"].split(",", 1)
+      assert header == "data:image/png;base64"


### PR DESCRIPTION
This PR adds tests that exercise Cog's built-in HTTP server.

Resolves https://github.com/zeke/cog-haiku/issues/7

cc @bfirsh @evilstreak