### PR TITLE
use latest cog with iterators

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -13,5 +13,8 @@ build:
 # image: r8.im/zeke/haiku-progressive
 # predict: "predict.py:ProgressivePredictor"
 
-image: r8.im/zeke/haiku-image
-predict: "predict.py:ImagePredictor"
+# image: r8.im/zeke/haiku-image
+# predict: "predict.py:ImagePredictor"
+
+image: r8.im/zeke/haiku-progressive-image
+predict: "predict.py:ProgressiveImagePredictor"

--- a/predict.py
+++ b/predict.py
@@ -1,7 +1,7 @@
 import random
 import tempfile
 import time
-from typing import Generator
+from typing import Iterator
 
 from colorthief import ColorThief
 from PIL import Image, ImageDraw, ImageFont
@@ -40,12 +40,13 @@ class ProgressivePredictor(HaikuBasePredictor):
     def predict(self, 
       seed: int = Input(description="A seed to always return the same result (optional)", ge=0, default=None),
       sleep: float = Input(description="Time to sleep between each word (when using progressive output)", default=0.1),
-      ) -> Generator[str, None, None]:
+      ) -> Iterator[str]:
 
         haiku = self.get_haiku(seed)
-
-        for word in haiku.split():
-          yield word
+        words = haiku.split(" ")
+        for i,_word in enumerate(words):
+          haiku_so_far = " ".join(words[0:i+1])
+          yield haiku_so_far
           time.sleep(sleep)
 
 

--- a/script/test
+++ b/script/test
@@ -9,7 +9,6 @@ if [ ! -d "cog" ]
 then
 git clone https://github.com/replicate/cog
 cd cog
-git switch future
 pip install -r requirements-dev.txt
 cd python
 python setup.py develop
@@ -19,4 +18,7 @@ fi
 # manually install python packages
 pip install pillow colorthief numpy fastapi
 
-pytest -s test_*.py
+# pytest -s test_*.py
+
+pytest -s test_http.py
+pytest -s test_predict.py

--- a/test_http.py
+++ b/test_http.py
@@ -49,7 +49,10 @@ class TestProgressivePredictor:
       client = make_client(ProgressivePredictor())
       resp = client.post("/predictions", json={"input": {"seed": 123}})
       assert resp.status_code == 200
-      assert resp.json() == {"status": "success", "output": "road"} # last word
+      assert resp.json()["status"] == "success"
+      assert resp.json()["output"][0] == "from"
+      assert resp.json()["output"][1] == "from somewhere\npear"
+      assert resp.json()["output"][-1] == "from somewhere\npear blossoms\n\na curve in the road"
 
 class TestImagePredictor:
   def test_returns_an_image(self):

--- a/test_predict.py
+++ b/test_predict.py
@@ -48,10 +48,10 @@ class TestProgressivePredictor:
     p = ProgressivePredictor()
     p.setup()
     output1 = [result for result in p.predict(sleep=0.01)]
-    assert(len(output1) > 5)
+    assert(len(output1) > 4)
 
     output2 = [result for result in p.predict(sleep=0.01)]
-    assert(len(output2) > 5)
+    assert(len(output2) > 4)
     
     assert output1 != output2
 

--- a/test_predict.py
+++ b/test_predict.py
@@ -42,8 +42,7 @@ class TestProgressivePredictor:
     p = ProgressivePredictor()
     p.setup()
     output = [result for result in p.predict(seed=123, sleep=0.1)]
-    assert(len(output) == 9)
-    assert(" ".join(output) == "from somewhere pear blossoms a curve in the road")
+    assert(output[-1] == 'from somewhere\npear blossoms\n\na curve in the road')
 
   def test_without_seed_returns_random_haiku(self):
     p = ProgressivePredictor()


### PR DESCRIPTION
This PR:

- updates the tests to build the cog python package from the main branch (no more `future`)
- updates the model to user Iterators instead of Generators. This was recently changed in Cog.
- updates the tests to match Cog's new progressive output format

This is some yak-shaving work to support progressive image outputs in this model, to test improvements to Replicate's progressive output sliders.