### PR TITLE
create multi-output predictor to test output order

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -5,6 +5,7 @@ build:
     - Pillow==9.0.1
     - colorthief==0.2.1
     - numpy==1.22.2
+
 # uncomment one of these before `cog push`:
 
 # image: r8.im/zeke/haiku-standard
@@ -16,5 +17,8 @@ build:
 # image: r8.im/zeke/haiku-image
 # predict: "predict.py:ImagePredictor"
 
-image: r8.im/zeke/haiku-progressive-image
-predict: "predict.py:ProgressiveImagePredictor"
+# image: r8.im/zeke/haiku-progressive-image
+# predict: "predict.py:ProgressiveImagePredictor"
+
+image: r8.im/zeke/haiku-multi-output
+predict: "predict.py:MultiOutputPredictor"

--- a/predict.py
+++ b/predict.py
@@ -7,7 +7,7 @@ from colorthief import ColorThief
 from PIL import Image, ImageDraw, ImageFont
 
 import haiku
-from cog import BasePredictor, Input, Path
+from cog import BasePredictor, BaseModel, Input, Path
 
 def haiku_to_words(haiku):
   return haiku.replace("\n", "\n ").split(" ")
@@ -116,3 +116,30 @@ class ProgressiveImagePredictor(HaikuBasePredictor):
           image_path = self.generate_image(haiku_so_far, bg_color=bg_color)
           yield Path(image_path)
           time.sleep(sleep)
+
+
+class Output(BaseModel):
+    # These are intentionally not in alphabetical order, so we know that the order is preserved
+    image: Path
+    text: str
+    seed: int
+
+class MultiOutputPredictor(HaikuBasePredictor):
+    """
+    Return haiku as an image and text (plus the seed).
+    """
+    def predict(self, 
+      seed: int = Input(description="A seed to always return the same result (optional)", ge=0, default=None),
+      source_image: Path = Input(description="An image from which to derive a background color for the output image (optional)", default=None),
+      ) -> Output:
+        haiku = self.get_haiku(seed)
+
+        # extract dominant color from source image for use in output image
+        if source_image and type(source_image) == str:
+          bg_color = ColorThief(source_image).get_color(quality=1)
+        else:
+          bg_color = None
+
+        image_path = self.generate_image(haiku, bg_color=bg_color)
+
+        return Output(text=haiku, image=image_path, seed=seed)

--- a/test_http.py
+++ b/test_http.py
@@ -2,7 +2,7 @@ from cog.server.http import create_app
 from fastapi.testclient import TestClient
 
 from cog import BasePredictor
-from predict import ImagePredictor, ProgressiveImagePredictor, ProgressivePredictor, StandardPredictor
+from predict import ImagePredictor, Output, ProgressiveImagePredictor, ProgressivePredictor, StandardPredictor, MultiOutputPredictor
 
 
 def make_client(predictor: BasePredictor, **kwargs) -> TestClient:
@@ -21,14 +21,14 @@ def test_setup_is_called():
     client = make_client(Predictor())
     resp = client.post("/predictions")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "success", "output": "bar"}
+    assert resp.json() == {"status": "succeeded", "output": "bar"}
 
 class TestStandardPredictor:
   def test_with_seed(self):
       client = make_client(StandardPredictor())
       resp = client.post("/predictions", json={"input": {"seed": 123}})
       assert resp.status_code == 200
-      assert resp.json() == {"status": "success", "output": "from an open barn\nthe odor of hay and manure\nand climbing roses"}
+      assert resp.json() == {"status": "succeeded", "output": "from an open barn\nthe odor of hay and manure\nand climbing roses"}
 
   def test_without_seed(self):
       client = make_client(StandardPredictor())
@@ -49,7 +49,7 @@ class TestProgressivePredictor:
       client = make_client(ProgressivePredictor())
       resp = client.post("/predictions", json={"input": {"seed": 123}})
       assert resp.status_code == 200
-      assert resp.json()["status"] == "success"
+      assert resp.json()["status"] == "succeeded"
       assert resp.json()["output"][0] == "from"
       assert resp.json()["output"][1] == "from an"
       assert resp.json()["output"][2] == "from an open"
@@ -65,7 +65,6 @@ class TestImagePredictor:
       header, b64data = resp.json()["output"].split(",", 1)
       assert header == "data:image/png;base64"
 
-
 class TestProgressiveImagePredictor:
   def test_returns_last_yielded_output(self):
       client = make_client(ProgressiveImagePredictor())
@@ -79,3 +78,12 @@ class TestProgressiveImagePredictor:
           header, b64data = img.split(",", 1)
           assert header == "data:image/png;base64"
           assert len(b64data) > 0
+
+class TestMultiOutputPredictor:
+  def test_returns_multiple_outputs(self):
+      client = make_client(MultiOutputPredictor())
+      resp = client.post("/predictions", json={"input": {"seed": 123}})
+      assert resp.status_code == 200
+      output = resp.json()["output"]
+      assert type(output) == dict
+      assert list(output.keys()) == ["image", "text", "seed"]


### PR DESCRIPTION
This is a test to ensure that the Cog HTTP server returns `Output()` keys in the order they're defined in the predictor.

Gonna use this to test that Replicate.com is correctly preserving output key order.

cc @chenxwh